### PR TITLE
logging wasn't working, looks like the CreateLogGroup permission may …

### DIFF
--- a/modules/ecs/policy-ecs.json
+++ b/modules/ecs/policy-ecs.json
@@ -8,6 +8,7 @@
                 "ecs:RegisterContainerInstance",
                 "ecs:StartTelemetrySession",
                 "ecs:Submit*",
+                "logs:CreateLogGroup",
                 "logs:CreateLogStream",
                 "logs:PutLogEvents",
                 "rekognition:*"

--- a/modules/services/policy-services.json.tpl
+++ b/modules/services/policy-services.json.tpl
@@ -4,6 +4,7 @@
             "Action": [
                 "s3:ListAllMyBuckets",
                 "s3:GetBucketLocation",
+                "logs:CreateLogGroup",
                 "logs:DescribeLogGroups",
                 "logs:CreateLogStream",
                 "logs:PutLogEvents",

--- a/modules/services/userdata.tpl
+++ b/modules/services/userdata.tpl
@@ -1,10 +1,10 @@
 #cloud-config
 package_upgrade: false
 runcmd:
-- /opt/graymeta/bin/aws_configurator -bucket ${file_storage_s3_bucket_arn} -usage-bucket ${usage_s3_bucket_arn} -region ${region} -encrypted-config-blob "${encrypted_config_blob}" >> /etc/graymeta/metafarm.env
 - sed -i 's/^log_group_name = .*/log_group_name = ${services_log_group}/' /var/awslogs/etc/awslogs.conf
-- systemctl daemon-reload
 - systemctl restart awslogs
+- /opt/graymeta/bin/aws_configurator -bucket ${file_storage_s3_bucket_arn} -usage-bucket ${usage_s3_bucket_arn} -region ${region} -encrypted-config-blob "${encrypted_config_blob}" >> /etc/graymeta/metafarm.env 2>/var/log/graymeta/aws_configurator.log
+- systemctl daemon-reload
 - systemctl restart docker-facebox.service
 - /opt/graymeta/bin/all-services.sh restart
 write_files:


### PR DESCRIPTION
…now be needed. Reordered the order of services started by cloud-init to be able to capture aws_configurator errors