### PR TITLE
Fix the DEPRECATED warnings

### DIFF
--- a/modules/ecs/variables.tf
+++ b/modules/ecs/variables.tf
@@ -11,9 +11,7 @@ variable "ssh_cidr_blocks" {
   description = "Comma delimited list of cidr blocks to allow SSH access from."
 }
 
-data "aws_region" "current" {
-  current = true
-}
+data "aws_region" "current" {}
 
 data "aws_subnet" "ecs_subnet" {
   id = "${var.subnet_id}"

--- a/modules/services/variables.tf
+++ b/modules/services/variables.tf
@@ -56,9 +56,7 @@ variable "ssh_cidr_blocks" {
   description = "Comma delimited list of cidr blocks to allow SSH access from."
 }
 
-data "aws_region" "current" {
-  current = true
-}
+data "aws_region" "current" {}
 
 data "aws_subnet" "subnet_1" {
   id = "${var.subnet_id_1}"


### PR DESCRIPTION
removing current will fix the messages.

Warning: module.platform.module.ecs.data.aws_region.current: "current": [DEPRECATED] Defaults to current provider region if no other filtering is enabled

You can find more info at https://github.com/terraform-providers/terraform-provider-aws/pull/3157