### PR TITLE
Adding aws_vpc_endpoint to s3 in same region

### DIFF
--- a/modules/network/gateway.tf
+++ b/modules/network/gateway.tf
@@ -39,3 +39,11 @@ resource "aws_nat_gateway" "services" {
     PlatformInstanceID = "${var.platform_instance_id}"
   }
 }
+
+resource "aws_vpc_endpoint" "s3" {
+  count             = "${var.gateway_endpoints ? 1 : 0}"
+  vpc_id            = "${aws_vpc.main.id}"
+  vpc_endpoint_type = "Gateway"
+  service_name      = "com.amazonaws.${var.region}.s3"
+  route_table_ids   = ["${aws_route_table.ecs.id}","${aws_route_table.services.id}"]
+}

--- a/modules/network/gateway.tf
+++ b/modules/network/gateway.tf
@@ -41,7 +41,6 @@ resource "aws_nat_gateway" "services" {
 }
 
 resource "aws_vpc_endpoint" "s3" {
-  count             = "${var.gateway_endpoints ? 1 : 0}"
   vpc_id            = "${aws_vpc.main.id}"
   vpc_endpoint_type = "Gateway"
   service_name      = "com.amazonaws.${var.region}.s3"

--- a/modules/network/variables.tf
+++ b/modules/network/variables.tf
@@ -77,3 +77,9 @@ variable "cidr_subnet_elasticsearch_2" {
   description = "The CIDR block to use for the elasticsearch 2 subnet"
   default     = "10.0.17.0/24"
 }
+
+variable "gateway_endpoints" {
+  type        = "string"
+  description = "Setup endpoint to s3 in the same region"
+  default     = true
+}

--- a/modules/network/variables.tf
+++ b/modules/network/variables.tf
@@ -77,9 +77,3 @@ variable "cidr_subnet_elasticsearch_2" {
   description = "The CIDR block to use for the elasticsearch 2 subnet"
   default     = "10.0.17.0/24"
 }
-
-variable "gateway_endpoints" {
-  type        = "string"
-  description = "Setup endpoint to s3 in the same region"
-  default     = true
-}


### PR DESCRIPTION
This will force all traffic to s3 in the same region through the endpoint instead of the NAT gateway.