### PR TITLE
constrain aws version provider to a minimum of 1.16

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,6 @@
 provider "aws" {
-  region = "${var.region}"
+  region  = "${var.region}"
+  version = "~> 1.16"
 }
 
 module "ecs" {


### PR DESCRIPTION
Got a couple errors because my copy of the aws provider was on an old version (1.10). Saw that support for user_data_base64 was added in 1.16, so pinned to at least that version:

```
Error: module.platform.module.ecs.aws_launch_configuration.launch_config_ecs: : invalid or unknown key: user_data_base64



Error: module.platform.module.services.aws_launch_configuration.launch_config_services: : invalid or unknown key: user_data_base64
```

https://www.terraform.io/docs/configuration/providers.html#provider-versions