### PR TITLE
GP-624: expose account lockout tuning parameters as TF variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,50 @@ All notable changes to this project will be documented in this file.
 ## [NOT RELEASED] - 2018-10-26
 
 #### Added
+
 * (Optional) No longer required for SES to be configured in the same region as the platform.  If you have SES in another region just add the following to the platform module.  Default is the same region as the platform if left blank.
 ```
     module "platform" {
       ...
       notifications_region = "us-west-2"
+      ...
+    }
+```
+
+* (Optional). Accounts will now be locked out after numerous failed login attempts in a given timeframe. The lockouts are tuneable with the following parameters:
+  * `account_lockout_attempts` - The number of failed login attempts that will trigger an account lockout. Default: 5
+  * `account_lockout_interval` - The amount of time an account is locked out after exceeding the threshold for number of failed logins. Default: 10m.  Valid values must be parseable as a Golang [time.Duration](https://godoc.org/time#ParseDuration)
+  * `account_lockout_period` - The window of time for failed login attempts to trigger an account lockout. Default: 10m.  Valid values must be parseable as a Golang [time.Duration](https://godoc.org/time#ParseDuration)
+```
+    module "platform" {
+      ...
+      account_lockout_attempts = "5"
+      account_lockout_interval = "10m"
+      account_lockout_period = "10m"
+      ...
+    }
+```
+
+* (Optional). Minimum password length is now a configurable option. Default is 8 characters long
+```
+    module "platform" {
+      ...
+      password_min_length = "8"
+      ...
+    }
+
+```
+
+#### Changed
+
+* (Optional). Box.com and Dropbox support has been refactored. Please see the [OAuth storage provider README](README-oauth-storage.md) for details.
+```
+    module "platform" {
+      ...
+      box_com_client_id  = "your box.com client id"
+      box_com_secret_key = "your box.com client secret"
+      dropbox_app_key    = "your Dropbox application key"
+      dropbox_app_secret = "your Dropbox application secret"
       ...
     }
 ```

--- a/main.tf
+++ b/main.tf
@@ -115,6 +115,7 @@ module "services" {
   min_cluster_size              = "${var.services_min_cluster_size}"
   notifications_from_addr       = "${var.notifications_from_addr}"
   notifications_region          = "${coalesce(var.notifications_region, var.region)}"
+  password_min_length           = "${var.password_min_length}"
   platform_access_cidrs         = "${var.platform_access_cidrs}"
   platform_instance_id          = "${var.platform_instance_id}"
   proxy_endpoint                = "${var.proxy_endpoint}"

--- a/main.tf
+++ b/main.tf
@@ -74,6 +74,9 @@ module "rds" {
 module "services" {
   source = "./modules/services"
 
+  account_lockout_attempts      = "${var.account_lockout_attempts}"
+  account_lockout_interval      = "${var.account_lockout_interval}"
+  account_lockout_period        = "${var.account_lockout_period}"
   ami_id                        = "${lookup(var.services_amis, var.region)}"
   az1_nat_ip                    = "${var.az1_nat_ip}"
   az2_nat_ip                    = "${var.az2_nat_ip}"

--- a/modules/services/auto_scaling.tf
+++ b/modules/services/auto_scaling.tf
@@ -112,6 +112,9 @@ data "template_file" "userdata" {
   template = "${file("${path.module}/userdata.tpl")}"
 
   vars {
+    account_lockout_attempts       = "${var.account_lockout_attempts}"
+    account_lockout_interval       = "${var.account_lockout_interval}"
+    account_lockout_period         = "${var.account_lockout_period}"
     box_com_client_id              = "${var.box_com_client_id}"
     box_com_secret_key             = "${var.box_com_secret_key}"
     client_secret_fe               = "${var.client_secret_fe}"

--- a/modules/services/auto_scaling.tf
+++ b/modules/services/auto_scaling.tf
@@ -147,6 +147,7 @@ data "template_file" "userdata" {
     harvest_complete_stow_fields   = "${var.harvest_complete_stow_fields}"
     harvest_polling_time           = "${var.harvest_polling_time}"
     jwt_key                        = "${var.jwt_key}"
+    password_min_length            = "${var.password_min_length}"
     region                         = "${var.region}"
     rollbar_token                  = "${var.rollbar_token}"
     s3subscriber_priority          = "${var.s3subscriber_priority}"

--- a/modules/services/userdata.tpl
+++ b/modules/services/userdata.tpl
@@ -97,6 +97,7 @@ write_files:
         harvest_magic_files=/etc/magic:/usr/share/misc/magic:/etc/graymeta/mime.magic
         harvest_rollbar_token=${rollbar_token}
         oauthconnect_url=https://${dns_name}:8443/connect
+        password_min_length=${password_min_length}
         rollbar_token=${rollbar_token}
         s3subscriber_priority=${s3subscriber_priority}
         stow_mountpath=/var/lib/graymeta/mounts

--- a/modules/services/userdata.tpl
+++ b/modules/services/userdata.tpl
@@ -33,6 +33,9 @@ write_files:
 -   content: |
         PATH=/opt/graymeta/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin
         SES_REGION=${from_region}
+        account_lockout_attempts=${account_lockout_attempts}
+        account_lockout_interval=${account_lockout_interval}
+        account_lockout_period=${account_lockout_period}
         box_com_client_id=${box_com_client_id}
         box_com_secret_key=${box_com_secret_key}
         dropbox_app_key=${dropbox_app_key}

--- a/modules/services/variables.tf
+++ b/modules/services/variables.tf
@@ -1,3 +1,6 @@
+variable "account_lockout_attempts" {}
+variable "account_lockout_interval" {}
+variable "account_lockout_period" {}
 variable "ami_id" {}
 variable "az1_nat_ip" {}
 variable "az2_nat_ip" {}

--- a/modules/services/variables.tf
+++ b/modules/services/variables.tf
@@ -39,6 +39,7 @@ variable "max_cluster_size" {}
 variable "min_cluster_size" {}
 variable "notifications_from_addr" {}
 variable "notifications_region" {}
+variable "password_min_length" {}
 variable "platform_access_cidrs" {}
 variable "platform_instance_id" {}
 variable "proxy_endpoint" {}

--- a/variables.tf
+++ b/variables.tf
@@ -308,6 +308,12 @@ variable "notifications_region" {
   default     = ""
 }
 
+variable "password_min_length" {
+  type        = "string"
+  description = "Minimum password length. Default: 8"
+  default     = "8"
+}
+
 variable "platform_access_cidrs" {
   type        = "string"
   description = "A comma delimited list of CIDRs from which to allow access to the site."

--- a/variables.tf
+++ b/variables.tf
@@ -1,3 +1,21 @@
+variable "account_lockout_attempts" {
+  type        = "string"
+  description = "The number of failed login attempts that will trigger an account lockout. Default: 5"
+  default     = "5"
+}
+
+variable "account_lockout_interval" {
+  type        = "string"
+  description = "The amount of time an account is locked out after exceeding the threshold for number of failed logins. Default: 10m.  Valid values must be parseable as a Golang time.Duration (see https://godoc.org/time#ParseDuration)"
+  default     = "10m"
+}
+
+variable "account_lockout_period" {
+  type        = "string"
+  description = "The window of time for failed login attempts to trigger an account lockout. Default: 10m.  Valid values must be parseable as a Golang time.Duration (see https://godoc.org/time#ParseDuration)"
+  default     = "10m"
+}
+
 variable "az1_nat_ip" {
   type        = "string"
   description = "The public IP all traffic from az1 is NAT'ed through to allow access to the APIs"


### PR DESCRIPTION
https://graymeta.atlassian.net/browse/GP-624

also exposes password minimum length as a configurable param:
https://graymeta.atlassian.net/browse/GP-621


xref: https://graymeta.atlassian.net/browse/GP-623
xref: https://github.com/graymeta/mf2/pull/4173
xref: https://github.com/graymeta/mf2/pull/4175