### PR TITLE
GP-907: userdata changes to enable support for amazon linux 2

### DIFF
--- a/modules/ecs/userdata.tpl
+++ b/modules/ecs/userdata.tpl
@@ -2,9 +2,9 @@
 package_upgrade: false
 runcmd:
 - echo "proxy=http://${proxy_endpoint}" >> /etc/yum.conf
-- echo "export HTTP_PROXY=http://${proxy_endpoint}" >> /etc/sysconfig/docker
-- echo "export HTTPS_PROXY=http://${proxy_endpoint}" >> /etc/sysconfig/docker
-- echo "export NO_PROXY=169.254.169.254" >> /etc/sysconfig/docker
+- mkdir -p /etc/systemd/system/docker.service.d
+- echo "[Service]" > /etc/systemd/system/docker.service.d/http-proxy.conf
+- echo "Environment=\"HTTP_PROXY=http://${proxy_endpoint}\" \"HTTPS_PROXY=http://${proxy_endpoint}\" \"NO_PROXY=localhost,127.0.0.1,169.254.169.254\"" >> /etc/systemd/system/docker.service.d/http-proxy.conf
 - echo "HTTP_PROXY=http://${proxy_endpoint}" >> /etc/ecs/ecs.config
 - echo "HTTPS_PROXY=http://${proxy_endpoint}" >> /etc/ecs/ecs.config
 - echo "NO_PROXY=169.254.169.254,169.254.170.2,/var/run/docker.sock" >> /etc/ecs/ecs.config
@@ -13,5 +13,6 @@ runcmd:
 - echo "env NO_PROXY=169.254.169.254,169.254.170.2,/var/run/docker.sock" >> /etc/init/ecs.override
 - echo ECS_CLUSTER=${ecs_cluster} >> /etc/ecs/ecs.config
 - mkdir /data
+- systemctl daemon-reload
 - service docker restart
 - start ecs


### PR DESCRIPTION
https://graymeta.atlassian.net/browse/GP-907

notes for configuring docker to use an http(s) proxy:
https://docs.docker.com/config/daemon/systemd/#httphttps-proxy