### PR TITLE
licensing: add .curio.app domain to proxy safelist so platform can reach licensing/usage servers

### DIFF
--- a/modules/network/variables.tf
+++ b/modules/network/variables.tf
@@ -205,6 +205,7 @@ variable "safelist" {
     ".amazonaws.com",
     ".box.com",
     ".boxcloud.com",
+    ".curio.app",
     ".cognitive.microsoft.com",
     ".core.windows.net",
     ".darksky.net",


### PR DESCRIPTION
servers will be hosted at {licensing,usage}.curio.app