### PR TITLE
Removing providers from modules

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,8 +1,3 @@
-provider "aws" {
-  region  = "${var.region}"
-  version = "~> 1.16"
-}
-
 module "amis" {
   source = "./modules/amis"
 }

--- a/modules/network/main.tf
+++ b/modules/network/main.tf
@@ -1,7 +1,3 @@
-provider "aws" {
-  region = "${var.region}"
-}
-
 resource "aws_vpc" "main" {
   cidr_block           = "${var.cidr_vpc}"
   enable_dns_hostnames = true

--- a/modules/s3_sqs/variables.tf
+++ b/modules/s3_sqs/variables.tf
@@ -30,10 +30,6 @@ variable "region" {
   description = "AWS region to setup SQS"
 }
 
-provider "aws" {
-  region = "${var.region}"
-}
-
 data "aws_s3_bucket" "bucket" {
   bucket = "${element(split(":", var.bucket_arn), length(split(":", var.bucket_arn)) - 1)}"
 }


### PR DESCRIPTION
Found an issue where if I have multiple providers that it will use the default aws creds since we have a provider in the modules.

Per Terraform.  
```
While in principle provider blocks can appear in any module, it is recommended that they be placed only in the root module of a configuration, since this approach allows users to configure providers just once and re-use them across all descendent modules.
```

I will do some testing with the latest versions and make sure all works.  If not I will add a note in the CHANGELOG to add `version = "~> 1.16"` to the provider they are using and to verify the region is setup properly on the provider.
