### PR TITLE
Update module usage add graymeta account

### DIFF
--- a/modules/usage/main.tf
+++ b/modules/usage/main.tf
@@ -3,6 +3,7 @@ data "template_file" "policy_usage" {
 
   vars {
     usage_s3_bucket_arn = "${var.usage_s3_bucket_arn}"
+    graymeta_account    = "${var.graymeta_account}"
   }
 }
 

--- a/modules/usage/policy-usage.json.tpl
+++ b/modules/usage/policy-usage.json.tpl
@@ -4,7 +4,7 @@
        {
             "Effect": "Allow",
             "Principal": {
-                "AWS": "arn:aws:iam::913397769129:root"
+                "AWS": "arn:aws:iam::${graymeta_account}:root"
             },
             "Action": [
                 "s3:GetBucketLocation",

--- a/modules/usage/variables.tf
+++ b/modules/usage/variables.tf
@@ -1,1 +1,10 @@
-variable "usage_s3_bucket_arn" {}
+variable "graymeta_account" {
+  type        = "string"
+  description = "The GrayMeta account number that will have permission to read the Usage bucket"
+  default     = "913397769129"
+}
+
+variable "usage_s3_bucket_arn" {
+  type        = "string"
+  description = "The Usage bucket ARN"
+}


### PR DESCRIPTION
This will help with testing that we can change the account and verify that cross account access is still working.  The default will be the account we are pulling info from today.

Also help if we need to change that in the future.