### PR TITLE
Enable SES Preflight

### DIFF
--- a/modules/services/userdata.tpl
+++ b/modules/services/userdata.tpl
@@ -46,6 +46,7 @@ write_files:
         AWS_REGION=${region}
         PATH=/opt/graymeta/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin
         SES_REGION=${from_region}
+        ses_region=${from_region}
         account_lockout_attempts=${account_lockout_attempts}
         account_lockout_interval=${account_lockout_interval}
         account_lockout_period=${account_lockout_period}


### PR DESCRIPTION
looks like the ENV for turning it on is `ses_region`
Looks case sensitive.

https://github.com/graymeta/gmkit/blob/master/notification/amazonses/ses.go#L17

Deployed on my test system.
```
	{
		"name": "AWS SES Account Sending Status",
		"message": "Sending has been enabled.",
		"status": 1
	},
	{
		"name": "AWS SES Verification Status - jason.sattler@graymeta.com",
		"message": "Address has been verified.",
		"status": 1
	},
```